### PR TITLE
build help, frozen doesn't require Cargo.lock

### DIFF
--- a/src/bin/build.rs
+++ b/src/bin/build.rs
@@ -69,7 +69,7 @@ Options:
     -q, --quiet                  No output printed to stdout
     --color WHEN                 Coloring: auto, always, never
     --message-format FMT         Error format: human, json [default: human]
-    --frozen                     Require Cargo.lock and cache are up to date
+    --frozen                     Require Cargo.lock (if-present) and cache are up to date
     --locked                     Require Cargo.lock is up to date
     -Z FLAG ...                  Unstable (nightly-only) flags to Cargo
 


### PR DESCRIPTION
The documentation message on `--frozen` is misleading. `--frozen` prevents reaching out to the network, and does require that the cache is up to date, and that Cargo.lock is up to date. It does however work if Cargo.lock is not present, which is important behavior for vendored build use cases with library sets.